### PR TITLE
Update ngrok to 4.0 & fix .env writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,9 +42,6 @@ class ServerlessTunnel {
           this.onConnect(url, envProp, ws, path)
         }
       })
-
-      ngrok.on('disconnect', () => this.onTunnelClose())
-      ngrok.on('error', (e) => this.errorHandler(e))
     } catch (e) {
       this.errorHandler(e)
     }

--- a/index.js
+++ b/index.js
@@ -28,20 +28,15 @@ class ServerlessTunnel {
     }
   }
 
-  runTunnel ({port, envProp, ws, path, ngrokOptions}) {
+  async runTunnel ({port, envProp, ws, path, ngrokOptions}) {
     try {
-      ngrok.connect({
+      const url = await ngrok.connect({
         addr: port,
         proto: 'http',
         region: 'eu',
         ...(ngrokOptions || {})
-      }, (err, url) => {
-        if (err) {
-          this.log(`Unable to create tunnel: ${err.message}`)
-        } else {
-          this.onConnect(url, envProp, ws, path)
-        }
       })
+      this.onConnect(url, envProp, ws, path)
     } catch (e) {
       this.errorHandler(e)
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "envfile": "^2.3.0",
     "lodash": "^4.17.10",
-    "ngrok": "2.3.0"
+    "ngrok": "^4"
   }
 }


### PR DESCRIPTION
Uses @tbehrsin's fix for updating ngrok to 4.0 in #7 and adds @alirussell's fix for writing the .env file with Ngrok 4 promises instead of callback during `runTunnel`