### PR TITLE
compatible with serverless v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 [![npm](https://img.shields.io/npm/v/serverless-ngrok-tunnel.svg)](https://www.npmjs.com/package/serverless-ngrok-tunnel)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
 
-Serverless plugin that creates ngrok public tunnel on localhost.  
+Serverless plugin that creates ngrok public tunnel on localhost.
 Optionally, writes tunnels url to .env file and deletes them after session is over. Useful for when you want to expose url for other applications to use (for example mobile application).
 
 ## Installation
 
-Add serverless-ngrok-tunnel to your project:  
-`npm install --save-dev serverless-ngrok-tunnel`  
+Add serverless-ngrok-tunnel to your project:
+`npm install --save-dev serverless-ngrok-tunnel`
 
-Then inside your `serverless.yml` file add following entry to the plugins section:  
+Then inside your `serverless.yml` file add following entry to the plugins section:
 ```yaml
 plugins:
   - serverless-ngrok-tunnel
@@ -35,18 +35,20 @@ custom:
         envProp: 'IOT_ENDPOINT'
         ws: true # expose web-socket url
         path: '/mqqt' # additional path to url
-        
+
       - port: 9000
         ngrokOptions: # optional. custom ngrok options
           authtoken: '12345'
           region: 'us'
           subdomain: 'my-subdomain'
-          
-```
-For a list of available ngrok options checkout ngrok [documentation](https://github.com/bubenshchykov/ngrok#options).  
 
-To start tunnel/s run `sls tunnel`.  
-If you are using `serverless-offline` plugin, start offline with option flag: `sls offline start --tunnel=true`.
+```
+For a list of available ngrok options checkout ngrok [documentation](https://github.com/bubenshchykov/ngrok#options).
+
+To start tunnel/s run `sls tunnel`.
+If you are using `serverless-offline` plugin
+  - v2: start offline with option flag: `sls offline start --tunnel=true`.
+  - v3: start offline with option flag: `sls offline start --param="tunnel=true"`.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class ServerlessTunnel {
         this.noEnvFile = true
       }
     }
-    if (this.slsOptions.tunnel === 'true' || selfInit) {
+    if (this.slsOptions.tunnel === 'true' || this.slsOptions.param?.includes('tunnel=true') || selfInit) {
       if (this.options.tunnels && this.options.tunnels.length) {
         this.log('Starting tunnels...')
         this.options.tunnels.forEach((opt) => this.runTunnel(opt))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-ngrok-tunnel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-ngrok-tunnel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Serverless plugin that creates ngrok public tunnel on localhost.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
serverless v3 passes params with `--param="tunnel=true"`, so making the code compatible with both v2 and v3.